### PR TITLE
Feat - Bench 547 - Check for cases where the certification platform does not match our mapping

### DIFF
--- a/front-end/flutter_confluence/lib/core/constants.dart
+++ b/front-end/flutter_confluence/lib/core/constants.dart
@@ -16,6 +16,7 @@ class Constants {
   static const GCP = 'gcp';
   static const AZURE = 'azure';
   static const CLOUD_NATIVE = 'cloud native foundation';
+  static const CNCF = 'cncf';
   static const HASHICORP = 'hashicorp';
   static const AWS = 'aws';
 

--- a/front-end/flutter_confluence/lib/domain/entities/cloud_certification.dart
+++ b/front-end/flutter_confluence/lib/domain/entities/cloud_certification.dart
@@ -21,6 +21,7 @@ class CloudCertification extends Equatable {
       case Constants.AZURE:
         return Constants.IC_AZURE;
       case Constants.CLOUD_NATIVE:
+      case Constants.CNCF:
         return Constants.IC_CLOUD_NATIVE;
       case Constants.HASHICORP:
         return Constants.IC_HASHICORP;


### PR DESCRIPTION
Added CNCF = "cncf" constant and mapping it to cloud native icon