### PR TITLE
[BENCH-880] Restore preloader logic for initial navigation

### DIFF
--- a/front-end/flutter_confluence/lib/core/components/preloader.dart
+++ b/front-end/flutter_confluence/lib/core/components/preloader.dart
@@ -31,9 +31,6 @@ class PreLoadWidget extends StatelessWidget {
         body: BlocListener(
             bloc: BlocProvider.of<AuthBloc>(context),
             listener: (context, state) {
-              // For testing purposes, let's go straight to the bottom
-              // nav screen as soon as the app opens.
-
               if (state is InvalidUser) {
                 Future.delayed(const Duration(milliseconds: STARTUP_DELAY_MILLIS), () {
                   _openOnBoardingPage(context);


### PR DESCRIPTION
## Ticket

https://ilabs-capco.atlassian.net/browse/BENCH-880

## Description

Restore the initial preloader logic to decide the initial page depending on if the user is logged or not.

## WIP

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

*PRs that should not be reviewed should be marked as a WIP.

- [ ] This PR is currently a work-in-progress.
- [x] This PR is ready for review.

## Checklist

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] All existing and new tests are passing.
- [x] My PR meets the acceptance criteria as outlined by my ticket.
- [x] I updated/added relevant documentation and comments (docs start with `///` and comments with `//`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

